### PR TITLE
docs: fix curly quotes in AD Users and Computers launcher readme

### DIFF
--- a/Scripts/SecretServer/Microsoft/Active Directory Users and Computers/Launchers/readme.md
+++ b/Scripts/SecretServer/Microsoft/Active Directory Users and Computers/Launchers/readme.md
@@ -8,4 +8,4 @@ MMC applications cannot be directly launched as [they require elevation](https:/
 1) Create a process launcher
 2) Select the **Run Process As Secret Credentials** and **Load User Profile** options
 3) Enter Process Name `powershell.exe`
-4) Enter Process Arguments	`-noprofile -executionpolicy bypass -windowstyle hidden -command cmd.exe -ArgumentList “/c dsa.msc”`
+4) Enter Process Arguments	`-noprofile -executionpolicy bypass -windowstyle hidden -command cmd.exe -ArgumentList "/c dsa.msc"`


### PR DESCRIPTION
## Summary
- The Process Arguments snippet in `Scripts/SecretServer/Microsoft/Active Directory Users and Computers/Launchers/readme.md` uses typographic (curly) quotes `“ ”` (U+201C / U+201D) around `/c dsa.msc`.
- PowerShell / cmd do not recognize curly quotes as string delimiters, so anyone copy-pasting the example builds a broken launcher.
- Replaced the two curly quotes with ASCII `"` to match every other launcher readme in the folder (ADSI Edit, Computer Management, DNS Manager, Event Viewer, Hyper-V, etc.).

This is the only file under `Scripts/SecretServer/Microsoft/` containing curly-quote bytes (verified by scanning all `.md` / `.txt` / `.ps1` files for `E2 80 9C / 9D / 98 / 99`).

## Test plan
- [x] `grep` for curly-quote bytes in the patched file returns 0 matches
- [x] `git diff` shows only the two characters changed on a single line
- [ ] Maintainer reviews rendered file on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)