### PR TITLE
Renumber migration inventory reports to 2.0, and bring LEGACY to parity

### DIFF
--- a/Reports/SecretServer/PlatformMigration/LEGACY-Platform_Migration_Inventory.sql
+++ b/Reports/SecretServer/PlatformMigration/LEGACY-Platform_Migration_Inventory.sql
@@ -1,4 +1,4 @@
-SELECT 'Report Version' AS [Item], '1.4.20260806-LEGACY' AS [Value], '' AS [Comment]
+SELECT 'Report Version' AS [Item], '1.5.20260806-LEGACY' AS [Value], '' AS [Comment]
 UNION ALL
 
 SELECT 'Report Date' AS [Item],

--- a/Reports/SecretServer/PlatformMigration/LEGACY-Platform_Migration_Inventory.sql
+++ b/Reports/SecretServer/PlatformMigration/LEGACY-Platform_Migration_Inventory.sql
@@ -1,4 +1,4 @@
-SELECT 'Report Version' AS [Item], '1.5.20260806-LEGACY' AS [Value], '' AS [Comment]
+SELECT 'Report Version' AS [Item], '2.0.20260806-LEGACY' AS [Value], '' AS [Comment]
 UNION ALL
 
 SELECT 'Report Date' AS [Item],

--- a/Reports/SecretServer/PlatformMigration/LEGACY-Platform_Migration_Inventory.sql
+++ b/Reports/SecretServer/PlatformMigration/LEGACY-Platform_Migration_Inventory.sql
@@ -828,32 +828,3 @@ UNION ALL
 
 SELECT '--> Metadata Items', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbMetadataItemData mid
-
-/*
-LEGACY variant of Platform_Migration_Inventory.sql - compatibility notes.
-
-Supported floor
-  Secret Server 11.0 or later.
-  SQL Server 2016 (compatibility level 130) or later.
-
-Deliberate differences from Platform_Migration_Inventory.sql
-  1. Nothing reads tbPlatformConfiguration, so '--> UsePlatformSettings' is omitted. That table
-     arrives in Secret Server 11.1 (SqlServer/11.1/000005.sql) and its UsePlatformSettings column
-     only in 11.5 (SqlServer/11.5/000012.sql). A missing table or column is a compile-time error
-     and cannot be guarded inside a single statement, so neither can be made conditional. The row
-     also carries no information for this audience: UsePlatformSettings is the unified-mode flag,
-     and an instance below 11.5 cannot be in unified mode, so the answer is always 'Disabled'.
-  2. No STRING_AGG anywhere. STRING_AGG is SQL Server 2017+. The Platform Adoption Ready comment is
-     built with STUFF over fixed CASE fragments, which reproduces the same ': '-joined output.
-  3. No XML-PATH string concatenation anywhere. The two name lists that the main report folds into a
-     Comment with that pattern are emitted as their own rows instead:
-       '----> IdP [name]'                  one row per active SAML IdP
-       '----> [source - scannertype]'      one row per active discovery source
-     '--> Discovery Sources' therefore keeps the simple COUNT over tbDiscoverySource rather than
-     counting across the join to tbDiscoveryScanner.
-
-Secret Server report engine rules observed here
-  No CTEs (derived tables only). No XML-PATH concatenation. No trailing semicolon. No SET statements.
-  No inline '--' comments. No 'user' token in an output column name - note the deliberate
-  'Custom Us'+'er Ownership' string split in the Platform Adoption Ready checks.
-*/

--- a/Reports/SecretServer/PlatformMigration/LEGACY-Platform_Migration_Inventory.sql
+++ b/Reports/SecretServer/PlatformMigration/LEGACY-Platform_Migration_Inventory.sql
@@ -1,376 +1,416 @@
-SELECT 'Report Version' AS [Item], '1.4.20250909-LEGACY' AS [Value], '' AS [Comment]
-
+SELECT 'Report Version' AS [Item], '1.4.20260806-LEGACY' AS [Value], '' AS [Comment]
 UNION ALL
 
-SELECT  'Report Date' AS [Item], 
-    CONVERT(VARCHAR, GETDATE(), 101) AS [Value], 
-    '' AS [Comment]
-
+SELECT 'Report Date' AS [Item],
+	CONVERT(VARCHAR, GETDATE(), 101) AS [Value],
+	'' AS [Comment]
 UNION ALL
 
 SELECT 'Platform Adoption Status' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
-SELECT
-    '--> Platform Adoption Ready' AS [Item],
-    CASE
-        WHEN EXISTS (SELECT * FROM tbDomain WHERE DomainTypeId IN (2, 3) AND Active = 1) THEN 'No'
-        WHEN (SELECT COUNT(*) FROM tbTeam WHERE Active = 1) > 0 THEN 'No'
-        WHEN (SELECT COUNT(*) FROM tbEventSubscription) > 0 THEN 'Possible'
-        WHEN (SELECT COUNT(*) FROM tbEventPipelinePolicy) > 0 THEN 'Possible'
-        WHEN (SELECT COUNT(*) FROM tbEventSubscription) = 0 AND (SELECT COUNT(*) FROM tbEventPipelinePolicy) = 0 THEN 'Yes'
-        ELSE 'Possible'
-    END AS [Value],
-    CASE
-        WHEN (SELECT COUNT(*) FROM tbEventSubscription) > 0 OR (SELECT COUNT(*) FROM tbEventPipelinePolicy) > 0 THEN 'To be Reviewed'
-        ELSE ''
-    END AS [Comment]
-
+SELECT '--> Platform Adoption Ready' AS [Item],
+	CASE
+		WHEN MAX(CASE WHEN Checks.Severity = 'No' THEN 1 ELSE 0 END) = 1 THEN 'No'
+		WHEN MAX(CASE WHEN Checks.Severity = 'Possible' THEN 1 ELSE 0 END) = 1 THEN 'Possible'
+		ELSE 'Yes'
+	END AS [Value],
+	ISNULL(STUFF(
+		ISNULL(MAX(CASE WHEN Checks.SortOrder = 1 THEN ': ' + Checks.ReviewItem END), '') +
+		ISNULL(MAX(CASE WHEN Checks.SortOrder = 2 THEN ': ' + Checks.ReviewItem END), '') +
+		ISNULL(MAX(CASE WHEN Checks.SortOrder = 3 THEN ': ' + Checks.ReviewItem END), '') +
+		ISNULL(MAX(CASE WHEN Checks.SortOrder = 4 THEN ': ' + Checks.ReviewItem END), '') +
+		ISNULL(MAX(CASE WHEN Checks.SortOrder = 5 THEN ': ' + Checks.ReviewItem END), '') +
+		ISNULL(MAX(CASE WHEN Checks.SortOrder = 6 THEN ': ' + Checks.ReviewItem END), '') +
+		ISNULL(MAX(CASE WHEN Checks.SortOrder = 7 THEN ': ' + Checks.ReviewItem END), '')
+	, 1, 2, ''), '') AS [Comment]
+FROM (
+	SELECT 'No' AS Severity, 'OpenLDAP Domains' AS ReviewItem, 1 AS SortOrder
+	WHERE EXISTS (SELECT * FROM tbDomain WITH (NOLOCK) WHERE DomainTypeId = 2 AND Active = 1)
+	UNION ALL
+	SELECT 'No', 'Teams Usage', 2
+	WHERE (SELECT COUNT(*) FROM tbTeam WITH (NOLOCK) WHERE Active = 1) > 0
+	UNION ALL
+	SELECT 'No', 'Integrated Windows Authentication', 3
+	WHERE (SELECT c.IntegratedWindowsAuthentication FROM tbConfiguration c WITH (NOLOCK)) = 1
+	UNION ALL
+	SELECT 'Possible', 'Event Subscriptions', 4
+	WHERE (SELECT COUNT(*) FROM tbEventSubscription WITH (NOLOCK)) > 0
+	UNION ALL
+	SELECT 'Possible', 'Event Pipelines', 5
+	WHERE (SELECT COUNT(*) FROM tbEventPipelinePolicy WITH (NOLOCK)) > 0
+	UNION ALL
+	SELECT 'No', 'Custom Us'+'er Ownership (' + CAST(UserOwnership.Cnt AS NVARCHAR(20)) + ' users)', 6
+	FROM (
+		SELECT COUNT(DISTINCT u.UserId) AS Cnt
+		FROM tbEntityOwnerPermission EOP WITH (NOLOCK)
+		JOIN tbUser u WITH (NOLOCK) ON u.UserId = EOP.OwnedEntityId
+		JOIN tbGroup g WITH (NOLOCK) ON EOP.GroupId = g.GroupId
+		WHERE EOP.RoleId = 14
+		AND u.Enabled = 1
+	) AS UserOwnership
+	WHERE UserOwnership.Cnt > 0
+	UNION ALL
+	SELECT 'No', 'Custom Group Ownership (' + CAST(GroupOwnership.Cnt AS NVARCHAR(20)) + ' groups)', 7
+	FROM (
+		SELECT COUNT(DISTINCT tg.GroupId) AS Cnt
+		FROM tbGroupOwnerPermission gop WITH (NOLOCK)
+		JOIN tbGroup tg WITH (NOLOCK) ON tg.GroupId = gop.OwnedGroupId
+		JOIN tbGroup og WITH (NOLOCK) ON og.GroupId = gop.GroupId
+		WHERE tg.Active = 1
+		AND og.Active = 1
+	) AS GroupOwnership
+	WHERE GroupOwnership.Cnt > 0
+) AS Checks
 UNION ALL
-
 
 SELECT 'Migration Package Size' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
-SELECT '--> Size' AS [Item], 
-    CASE 
+SELECT '--> Size' AS [Item],
 
-        WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) < 2500 
-            AND (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) < 2 THEN 'Small'
-        WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) BETWEEN 2501 AND 10000 
-            AND (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) BETWEEN 3 AND 7 THEN 'Medium'
-        WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) BETWEEN 10001 AND 25000 
-            AND (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) > 7 THEN 'Large'
-        WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) > 25001
-            AND (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) > 7 THEN 'Custom'
-
-        WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) > 10001 THEN 'Large'
-        WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) BETWEEN 2501 AND 10000 THEN 'Medium'
-        WHEN (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) > 7 THEN 'Large'
-        WHEN (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) BETWEEN 3 AND 7 THEN 'Medium'
-        ELSE 'Small' 
-    END AS [Value], '' AS [Comment]
-
+	CASE
+		WHEN (SELECT COUNT(*) FROM tbsite WHERE Active = 1) > 10 THEN 'Custom'
+		WHEN (SELECT COUNT(*) FROM tbsite WHERE Active = 1) BETWEEN 5 AND 10 AND
+			 (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) < 2500 AND
+			 (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) < 2 THEN 'Large'
+		WHEN (SELECT COUNT(*) FROM tbsite WHERE Active = 1) BETWEEN 5 AND 10 THEN 'Custom'
+		WHEN (SELECT COUNT(*) FROM tbsite WHERE Active = 1) BETWEEN 3 AND 4 AND
+			 (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) < 2500 AND
+			 (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) < 2 THEN 'Medium'
+		WHEN (SELECT COUNT(*) FROM tbsite WHERE Active = 1) BETWEEN 3 AND 4 AND
+			 (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) BETWEEN 2501 AND 10000 AND
+			 (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) BETWEEN 3 AND 7 THEN 'Large'
+		WHEN (SELECT COUNT(*) FROM tbsite WHERE Active = 1) BETWEEN 3 AND 4 THEN 'Custom'
+		WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) > 25000 THEN 'Custom'
+		WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) < 2500 AND
+			 (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) < 2 THEN 'Small'
+		WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) BETWEEN 2501 AND 10000 AND
+			 (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) > 7 THEN 'Custom'
+		WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) BETWEEN 2501 AND 10000 AND
+			 (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) BETWEEN 3 AND 7 THEN 'Large'
+		WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) BETWEEN 2501 AND 10000 THEN 'Medium'
+		WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) BETWEEN 10001 AND 25000 THEN 'Large'
+		WHEN (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) > 7 THEN 'Large'
+		WHEN (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) BETWEEN 3 AND 7 THEN 'Medium'
+		ELSE 'Small'
+	END AS [Value],
+	CASE
+		WHEN (SELECT COUNT(*) FROM tbsite WHERE Active = 1) > 10 THEN 'site count'
+		WHEN (SELECT COUNT(*) FROM tbsite WHERE Active = 1) BETWEEN 5 AND 10 AND
+			 NOT ((SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) < 2500 AND
+			      (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) < 2) THEN 'site count'
+		WHEN (SELECT COUNT(*) FROM tbsite WHERE Active = 1) BETWEEN 3 AND 4 AND
+			 NOT ((SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) < 2500 AND
+			      (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) < 2) AND
+			 NOT ((SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) BETWEEN 2501 AND 10000 AND
+			      (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) BETWEEN 3 AND 7) THEN 'site count'
+		WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) > 25000 THEN 'secret count exceeds X3 ceiling'
+		WHEN (SELECT COUNT(SecretID) FROM tbSecret WHERE Active = 1) BETWEEN 2501 AND 10000 AND
+			 (SELECT COUNT(*) FROM tbSdkClientAccount WHERE Revoked <> 1) > 7 THEN 'SDK account count escalation'
+		ELSE ''
+	END AS [Comment]
 UNION ALL
 
 SELECT 'Directory Services Information' AS [Item], '' AS [Value], '' AS [Comment]
-
-UNION ALL 
+UNION ALL
 
 SELECT '--> Number of Domains', CAST(COUNT(DomainId) AS NVARCHAR(50)) AS [Value], ''
 FROM tbDomain d
 WHERE d.Active = 1
-
 UNION ALL
 
-SELECT 
-    '--> Entra ID-Directory Services' AS [Item],
-    CASE 
-        WHEN EXISTS (SELECT * FROM tbDomain WHERE DomainTypeId = 3 AND Active = 1) THEN 'Yes'
-        ELSE 'No' 
-    END AS [Value], '' AS [Comment]
-
+SELECT '--> Entra ID-Directory Services' AS [Item],
+	CASE
+		WHEN EXISTS (SELECT * FROM tbDomain WHERE DomainTypeId = 3 AND Active = 1) THEN
+			'Yes (' + CAST((SELECT COUNT(*) FROM tbDomain WHERE DomainTypeId = 3 AND Active = 1) AS VARCHAR) + ')'
+		ELSE 'No'
+	END AS [Value], '' AS [Comment]
 UNION ALL
 
-SELECT 
-    '--> OpenLDAP-Directory Services' AS [Item],
-    CASE 
-        WHEN EXISTS (SELECT * FROM tbDomain WHERE DomainTypeId = 2 AND Active = 1) THEN 'Yes'
-        ELSE 'No' 
-    END AS [Value], '' AS [Comment]
+SELECT '--> Active Directory-Directory Services' AS [Item],
+	CASE
+		WHEN EXISTS (SELECT * FROM tbDomain WHERE DomainTypeId = 1 AND Active = 1) THEN
+			'Yes (' + CAST((SELECT COUNT(*) FROM tbDomain WHERE DomainTypeId = 1 AND Active = 1) AS VARCHAR) + ')'
+		ELSE 'No'
+	END AS [Value], '' AS [Comment]
+UNION ALL
 
+SELECT '--> OpenLDAP-Directory Services' AS [Item],
+	CASE
+		WHEN EXISTS (SELECT * FROM tbDomain WHERE DomainTypeId = 2 AND Active = 1) THEN
+			'Yes (' + CAST((SELECT COUNT(*) FROM tbDomain WHERE DomainTypeId = 2 AND Active = 1) AS VARCHAR) + ')'
+		ELSE 'No'
+	END AS [Value], '' AS [Comment]
 UNION ALL
 
 SELECT 'Core Configuration' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
-
 
 SELECT '--> Secret Server Address' AS [Item], CAST(c.CustomURL AS NVARCHAR(255)) AS [Value], '' AS [Comment]
 FROM tbConfiguration c
-
 UNION ALL
 
-
-SELECT '--> Secret Server Version' AS [Item], CAST(v.VersionNumber AS NVARCHAR(50)) AS [Value], '' AS [Comment]
+SELECT '--> Secret Server Version' AS [Item],
+   CAST(v.VersionNumber AS NVARCHAR(50)) AS [Value],
+   (SELECT CASE
+       WHEN DATEADD(MONTH, -11, GETDATE()) > v.Upgraded THEN 'Last Upgrade > 11months'
+       WHEN (
+            SELECT CAST(
+                RIGHT('00' + PARSENAME(v.VersionNumber, 3), 2) +
+                RIGHT('00' + PARSENAME(v.VersionNumber, 2), 2)
+            AS INT)
+       ) < 1109 THEN 'Upgrade Required < v11.10'
+       ELSE ''
+   END) AS [Comment]
 FROM (
-    SELECT TOP 1 v.VersionNumber
-    FROM tbVersion v
-    ORDER BY v.Upgraded DESC, v.VersionNumber DESC
+   SELECT TOP 1 v.VersionNumber, v.Upgraded
+   FROM tbVersion v
+   ORDER BY v.Upgraded DESC, v.VersionNumber DESC
 ) v
-
 UNION ALL
 
 SELECT '--> Number of Web Servers' AS [Item], CAST(COUNT(NodeId) AS NVARCHAR(50)) AS [Value], '' AS [Comment]
 FROM tbNode n
-
 UNION ALL
 
-
-SELECT '--> Integrated Windows Auth' AS [Item], 
-    CAST(CASE 
-        WHEN c.IntegratedWindowsAuthentication = 0 THEN 'FALSE' 
-        WHEN c.IntegratedWindowsAuthentication = 1 THEN 'TRUE' 
-    END AS NVARCHAR(5)) AS [Value], '' AS [Comment]
+SELECT '--> Integrated Windows Auth' AS [Item],
+	CAST(CASE
+		WHEN c.IntegratedWindowsAuthentication = 0 THEN 'FALSE'
+		WHEN c.IntegratedWindowsAuthentication = 1 THEN 'TRUE'
+	END AS NVARCHAR(5)) AS [Value], '' AS [Comment]
 FROM tbConfiguration c
-
 UNION ALL
 
-
-SELECT '--> SAML Enabled' AS [Item], 
-    CAST(CASE 
-        WHEN sc.Enabled = 0 THEN 'FALSE' 
-        WHEN sc.Enabled = 1 THEN 'TRUE' 
-    END AS NVARCHAR(5)) AS [Value], '' AS [Comment]
+SELECT '--> SAML Enabled' AS [Item],
+	CAST(CASE
+		WHEN sc.Enabled = 0 THEN 'FALSE'
+		WHEN sc.Enabled = 1 THEN 'TRUE'
+	END AS NVARCHAR(5)) AS [Value], '' AS [Comment]
 FROM tbSamlConfiguration sc
-
 UNION ALL
 
-SELECT '--> Allow Duplicate Secrets', 
-    CAST(CASE 
-        WHEN c.AllowDuplicateSecretNames = 0 THEN 'FALSE' 
-        WHEN c.AllowDuplicateSecretNames = 1 THEN 'TRUE' 
-    END AS NVARCHAR(5)), ''
-FROM tbConfiguration c
-
+SELECT CONCAT('----> IdP [', spi.DisplayName, ']') AS [Item], 'Active' AS [Value], '' AS [Comment]
+FROM tbSamlIdpConfiguration spi
+WHERE spi.Active = 1
 UNION ALL
 
-SELECT '--> Require Folder for Secrets', 
-    CAST(CASE 
-        WHEN c.RequireFolderForSecret = 0 THEN 'FALSE' 
-        WHEN c.RequireFolderForSecret = 1 THEN 'TRUE' 
-    END AS NVARCHAR(5)), ''
+SELECT '--> Allow Duplicate Secrets',
+	CAST(CASE
+		WHEN c.AllowDuplicateSecretNames = 0 THEN 'FALSE'
+		WHEN c.AllowDuplicateSecretNames = 1 THEN 'TRUE'
+	END AS NVARCHAR(5)), ''
 FROM tbConfiguration c
-
 UNION ALL
 
-SELECT '--> Password Rotation Enabled', 
-    CAST(CASE 
-        WHEN c.EnablePasswordChanging = 0 THEN 'FALSE' 
-        WHEN c.EnablePasswordChanging = 1 THEN 'TRUE' 
-    END AS NVARCHAR(5)), ''
+SELECT '--> Require Folder for Secrets',
+	CAST(CASE
+		WHEN c.RequireFolderForSecret = 0 THEN 'FALSE'
+		WHEN c.RequireFolderForSecret = 1 THEN 'TRUE'
+	END AS NVARCHAR(5)), ''
 FROM tbConfiguration c
-
 UNION ALL
 
-SELECT '--> Heartbeat Globally Enabled', 
-    CAST(CASE 
-        WHEN c.EnableHeartBeat = 0 THEN 'FALSE' 
-        WHEN c.EnableHeartBeat = 1 THEN 'TRUE' 
-    END AS NVARCHAR(5)), ''
+SELECT '--> Password Rotation Enabled',
+	CAST(CASE
+		WHEN c.EnablePasswordChanging = 0 THEN 'FALSE'
+		WHEN c.EnablePasswordChanging = 1 THEN 'TRUE'
+	END AS NVARCHAR(5)), ''
 FROM tbConfiguration c
+UNION ALL
 
+SELECT '--> Heartbeat Globally Enabled',
+	CAST(CASE
+		WHEN c.EnableHeartBeat = 0 THEN 'FALSE'
+		WHEN c.EnableHeartBeat = 1 THEN 'TRUE'
+	END AS NVARCHAR(5)), ''
+FROM tbConfiguration c
 UNION ALL
 
 SELECT 'Site Information' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
 SELECT '--> Number of Sites', CAST(COUNT(SiteId) AS NVARCHAR(50)), ''
 FROM tbSite si
 WHERE si.Active = 1
-
 UNION ALL
 
-SELECT DISTINCT CONCAT('----> Engines in Site ', S.SiteName), 
-    CAST(COUNT(EngineId) OVER (PARTITION BY S.SiteName) AS NVARCHAR(50)), ''
+SELECT DISTINCT CONCAT('----> Engines in Site ', S.SiteName),
+	CAST(COUNT(EngineId) OVER (PARTITION BY S.SiteName) AS NVARCHAR(50)), ''
 FROM tbEngine E
 JOIN tbSite S ON S.SiteId = E.SiteId
 WHERE E.ActivationStatus = 1
-
 UNION ALL
 
 SELECT 'Users and Groups' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
 SELECT '--> Number of Active Users in the last 6 months', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbUser u
 WHERE u.LastLogin >= DATEADD(MONTH, -6, GETDATE())
-
 UNION ALL
 
 SELECT '--> Number of Automatically Disabled Users', CAST(COUNT(*) AS NVARCHAR(50)) AS [Value], ''
 FROM tbUser
 WHERE DisabledByAutomaticADUserDisabling = 1
-
 UNION ALL
 
 SELECT '--> Total Number of Users', CAST(COUNT(UserId) AS NVARCHAR(50)), ''
 FROM tbUser u
 WHERE u.Enabled = 1
-
 UNION ALL
-
 
 SELECT '--> Domain Users', CAST(COUNT(UserId) AS NVARCHAR(50)), ''
 FROM tbUser u
 WHERE u.Enabled = 1 AND u.DomainId IS NOT NULL
-
 UNION ALL
 
 SELECT '--> Local Users', CAST(COUNT(UserId) AS NVARCHAR(50)), ''
 FROM tbUser u
 WHERE u.Enabled = 1 AND u.DomainId IS NULL
-
 UNION ALL
 
 SELECT '--> Total Number of Application Accounts', CAST(COUNT(UserId) AS NVARCHAR(50)), ''
 FROM tbUser u
 WHERE u.Enabled = 1 AND u.IsApplicationAccount = 1
-
 UNION ALL
 
 SELECT '-->   Local Application Accounts' AS Item, CAST(COUNT(UserId) AS NVARCHAR(50)) AS Value, '' AS Comment
-FROM tbUser u WHERE u.Enabled = 1 AND u.IsApplicationAccount = 1 AND u.DomainId IS NULL
-
+FROM tbUser u
+WHERE u.Enabled = 1 AND u.IsApplicationAccount = 1 AND u.DomainId IS NULL
 UNION ALL
 
 SELECT '-->   Domain Application Accounts' AS Item, CAST(COUNT(UserId) AS NVARCHAR(50)) AS Value, '' AS Comment
-FROM tbUser u WHERE u.Enabled = 1 AND u.IsApplicationAccount = 1 AND u.DomainId IS NOT NULL
-
+FROM tbUser u
+WHERE u.Enabled = 1 AND u.IsApplicationAccount = 1 AND u.DomainId IS NOT NULL
 UNION ALL
 
 SELECT '--> Total Numbers of Groups' AS [Item], CAST(COUNT(GroupId) AS NVARCHAR(50)) AS [Value], '' AS [Comment]
 FROM tbGroup g
 WHERE g.Active = 1
-
 UNION ALL
 
 SELECT '-->   Active Directory Groups' AS [Item], CAST(COUNT(GroupId) AS NVARCHAR(50)) AS [Value], '' AS [Comment]
 FROM tbGroup g
 WHERE g.DomainId IS NOT NULL AND g.Active = 1
-
 UNION ALL
 
 SELECT '-->   Local Groups' AS [Item], CAST(COUNT(GroupId) AS NVARCHAR(50)) AS [Value], '' AS [Comment]
 FROM tbGroup g
 WHERE g.DomainId IS NULL AND g.Active = 1
-
 UNION ALL
-	
-SELECT '--> Roles', 
+
+SELECT '--> Roles',
        CAST(COUNT(RoleId) AS NVARCHAR(50)) AS [Value], '' AS [Comment]
 FROM tbRole r
 WHERE r.Active = 1
   AND r.IsSystem <> 1
 UNION ALL
 
-SELECT '-->   Users with custom ownership', cast(count([userid]) as NVARCHAR(50)), ''
-from (
-select distinct userid from (
-SELECT U.UserId
-	,u.username as [ManangedUser]
-	,g.GroupName as [Managed By]
-  FROM [tbEntityOwnerPermission] EOP
-  join tbuser u on u.userid = eop.OwnedEntityId
-  join tbGroup g on eop.GroupId = g.GroupID
-  where roleid =14 
-  and u.Enabled = 1) as result) as result
-
+SELECT '-->   Users with custom ownership', CAST(COUNT([userid]) AS NVARCHAR(50)), ''
+FROM (
+	SELECT DISTINCT userid
+	FROM (
+		SELECT U.UserId
+			,u.username AS [ManangedUser]
+			,g.GroupName AS [Managed By]
+		FROM [tbEntityOwnerPermission] EOP
+		JOIN tbuser u ON u.userid = eop.OwnedEntityId
+		JOIN tbGroup g ON eop.GroupId = g.GroupID
+		WHERE roleid = 14
+		AND u.Enabled = 1
+	) AS result
+) AS result
 UNION ALL
 
-SELECT '-->   Groups with custom ownership', 
-       CAST(COUNT(DISTINCT tg.groupid) AS NVARCHAR(50)) AS [Value], 
-       '' AS [Comment]
+SELECT '-->   Groups with custom ownership',
+	   CAST(COUNT(DISTINCT tg.groupid) AS NVARCHAR(50)) AS [Value],
+	   '' AS [Comment]
 FROM tbGroupOwnerPermission gop
 JOIN tbgroup tg ON tg.GroupID = gop.OwnedGroupId
 JOIN tbgroup og ON og.GroupID = gop.GroupId
-WHERE tg.Active = 1 
+WHERE tg.Active = 1
 AND og.Active = 1
-
-
 UNION ALL
 
 SELECT 'Secret Templates' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
 SELECT '--> Modified Templates', CAST(COUNT(DISTINCT CAST(a.ItemId AS INT)) AS NVARCHAR(50)), ''
 FROM tbAudit a
 JOIN tbSecretType st ON a.ItemId = st.SecretTypeID
 WHERE a.AuditTypeId = 3 AND a.Notes LIKE 'Field%'
-
 UNION ALL
 
 SELECT '--> Custom Templates', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbAudit a
 WHERE a.AuditTypeId = 3 AND a.Action LIKE '%EATE'
-
 UNION ALL
 
 SELECT '--> Custom Scripts', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbAudit a
 WHERE a.AuditTypeId = 5 AND a.Action LIKE '%EATE'
-
 UNION ALL
 
 SELECT '--> Custom Launchers', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbAudit a
 WHERE a.AuditTypeId = 4 AND a.Action LIKE '%EATE'
-
 UNION ALL
 
 SELECT '--> Custom Password Changers', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbPasswordTypeAudit pta
 WHERE pta.Action LIKE '%EATE' AND pta.Notes NOT LIKE '%Pass%'
-
 UNION ALL
 
 SELECT '--> Custom Password Requirements', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbPasswordRequirementAudit pra
 WHERE pra.Action LIKE '%EATE'
-
 UNION ALL
 
 SELECT '--> Custom Character Sets', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbCharacterSetAudit csa
 WHERE csa.Action LIKE '%EATE'
-
 UNION ALL
 
 SELECT 'Secret Policies' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
 SELECT '--> Number of Policies', CAST(COUNT(SecretPolicyId) AS NVARCHAR(50)), ''
 FROM tbSecretPolicy p
 WHERE p.Active = 1
-
 UNION ALL
 
 SELECT '--> Direct Secret Policy Assignments', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbSecret s
 WHERE s.Active = 1 AND s.SecretPolicyId IS NOT NULL AND s.EnableInheritSecretPolicy = 0
-
 UNION ALL
 
 SELECT '--> Folder Policy Assignments', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbfolder f
 JOIN tbSecretPolicy sp ON f.SecretPolicyId = sp.SecretPolicyId
 WHERE sp.Active = 1 AND f.EnableInheritSecretPolicy = 0
-
 UNION ALL
 
 SELECT 'Discovery Information' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
-SELECT '--> Discovery Enabled', 
-    CAST(CASE 
-        WHEN dc.EnableDiscovery = 0 THEN 'FALSE' 
-        WHEN dc.EnableDiscovery = 1 THEN 'TRUE' 
-    END AS NVARCHAR(5)), ''
+SELECT '--> Discovery Enabled',
+	CAST(CASE
+		WHEN dc.EnableDiscovery = 0 THEN 'FALSE'
+		WHEN dc.EnableDiscovery = 1 THEN 'TRUE'
+	END AS NVARCHAR(5)), ''
 FROM tbDiscoveryConfiguration dc
-
 UNION ALL
 
 SELECT '--> Discovery Sources', CAST(COUNT(DiscoverySourceId) AS NVARCHAR(50)), ''
 FROM tbDiscoverySource ds
 WHERE ds.Active = 1
+UNION ALL
 
+SELECT CONCAT('----> [', ds.Name, ' - ', sc.ScannerTypeName, ']') AS [Item], '' AS [Value], '' AS [Comment]
+FROM tbDiscoverySource ds
+JOIN tbDiscoveryScanner sc ON sc.DiscoveryScannerId = ds.DiscoveryScannerId
+WHERE ds.Active = 1
 UNION ALL
 
 SELECT '--> Discovery Import Rules', CAST(COUNT(DiscoveryImportRuleId) AS NVARCHAR(50)), ''
@@ -379,20 +419,19 @@ WHERE dr.Active = 1
 UNION ALL
 
 SELECT 'Secret Information' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
 SELECT '--> Number of Secrets', CAST(COUNT(SecretID) AS NVARCHAR(50)), ''
 FROM tbSecret s
 WHERE s.Active = 1
-
 UNION ALL
 
 SELECT '--> Secrets in Personal Subfolders', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbSecret s
 JOIN tbfolder f ON s.FolderId = f.FolderID
-WHERE s.Active = 1 AND f.FolderPath LIKE '%PERSONAL Folders\%'
-
+CROSS JOIN (SELECT PersonalFolderName FROM tbConfiguration) cfg
+WHERE s.Active = 1
+    AND f.FolderPath LIKE '%' + cfg.PersonalFolderName + '\%\%'
 UNION ALL
 
 SELECT '--> Secrets With Files', CAST(COUNT(*) AS NVARCHAR(50)), ''
@@ -401,7 +440,6 @@ JOIN tbSecretField sf ON si.SecretFieldID = sf.SecretFieldID
 JOIN tbFileAttachment fa ON si.FileAttachmentId = fa.FileAttachmentId
 JOIN tbSecret s ON si.SecretID = s.SecretID
 WHERE sf.IsFile = 1 AND s.Active = 1
-
 UNION ALL
 
 SELECT '--> Secrets with OTP Codes Added', CAST(COUNT(*) AS NVARCHAR(50)), ''
@@ -410,48 +448,84 @@ JOIN tbFolder f ON s.FolderID = f.FolderID
 JOIN tbSecretType t ON s.SecretTypeID = t.SecretTypeID
 LEFT JOIN tbSecretOneTimePasswordSettings otp ON otp.SecretId = s.SecretID
 WHERE s.Active = 1 AND otp.Enabled = 1
-
 UNION ALL
 
-SELECT DISTINCT CONCAT('--> Proxied Secrets - Site [', list.SiteName, '] Type - ', list.Type), 
-    CAST(COUNT(secretid) OVER (PARTITION BY [Type], Sitename) AS NVARCHAR(50)), ''
-FROM (
-    SELECT s.Secretid,
-        CASE
-            WHEN pt.typename LIKE '%activeDirectory%' OR pt.typename LIKE '%WindowsAccount%' THEN 'RDP'
-            WHEN pt.typename LIKE '%UnixSSH%' THEN 'Unix/SSH'
-            ELSE CONCAT('Other: ', REVERSE(SUBSTRING(REVERSE(PT.TYPENAME), 1, CHARINDEX('.', REVERSE(PT.TYPENAME)) - 1)))
-        END AS [Type],
-        site.SiteName
-    FROM tbSecret s
-    JOIN tbSecretType t ON s.SecretTypeID = t.SecretTypeID
-    JOIN tbPasswordType pt ON t.PasswordTypeId = pt.PasswordTypeId
-    JOIN tbSite site ON site.SiteId = s.SiteId
-    WHERE s.IsSSHProxyEnabled = 1 AND s.Active = 1
-) list
+SELECT '--> Secrets with Hooks' AS [Item],
+	CAST(COUNT(DISTINCT sh.SecretId) AS VARCHAR(50)) AS [Value],
+	'' AS [Comment]
+FROM tbSecretHook sh
+JOIN tbSecret s ON sh.SecretId = s.SecretId
+WHERE s.Active = 1
+UNION ALL
 
+SELECT '-->  Total Count of Hooks' AS [Item],
+	CAST((SELECT COUNT(*) FROM tbSecretHook) AS VARCHAR(50)) AS [Value],
+	'' AS [Comment]
+UNION ALL
+
+SELECT 'Proxying Config' AS [Item], '' AS [Value], '' AS [Comment]
+UNION ALL
+
+SELECT '--> Proxy Features Enabled' AS [Item],
+	CASE WHEN EnableRDPProxy = 1 THEN '(RDP)' ELSE '' END +
+	CASE WHEN EnableSSHProxy = 1 THEN '(SSH)' ELSE '' END  +
+	CASE WHEN EnableSSHProxyRDPTunneling = 1 THEN '(RDP over SSH)' ELSE '' END +
+	CASE WHEN (EnableRDPProxy = 0 AND EnableSSHProxy = 0 AND EnableSSHProxyRDPTunneling = 0) THEN 'None' ELSE '' END AS [Value],
+	'' AS [Comment]
+FROM tbAdminProxyingConfiguration
+UNION ALL
+
+SELECT '--> Proxy New Secret By Default Setting' AS [Item],
+	CASE WHEN ProxyByDefault = 1 THEN 'ENABLED' ELSE 'DISABLED' END AS [Value],
+	'' AS [Comment]
+FROM tbAdminProxyingConfiguration
+UNION ALL
+
+SELECT CONCAT('--> Site [', s.SiteName, '] Proxy Status') AS [Item],
+	CASE WHEN s.EnableProxy = 1 THEN 'SSH: On' ELSE 'SSH: Off' END +
+	CASE WHEN s.EnableRDPProxy = 1 THEN ' | RDP: On' ELSE ' | RDP: Off' END +
+	' - ' + CAST(COUNT(e.EngineId) AS VARCHAR(10)) + ' Active Engines' AS [Value],
+	'' AS [Comment]
+FROM tbSite s
+LEFT JOIN tbEngine e ON s.SiteId = e.SiteId AND e.ActivationStatus = 1
+WHERE s.EnableProxy = 1 OR s.EnableRDPProxy = 1
+GROUP BY s.SiteId, s.SiteName, s.EnableProxy, s.EnableRDPProxy
+UNION ALL
+
+SELECT DISTINCT CONCAT('--> Proxied Secrets - Site [', list.SiteName, '] Type - ', list.Type),
+	CAST(COUNT(secretid) OVER (PARTITION BY [Type], Sitename) AS NVARCHAR(50)), ''
+FROM (
+	SELECT s.Secretid,
+		CASE
+			WHEN pt.typename LIKE '%activeDirectory%' OR pt.typename LIKE '%WindowsAccount%' THEN 'RDP'
+			WHEN pt.typename LIKE '%UnixSSH%' THEN 'Unix/SSH'
+			ELSE CONCAT('Other: ', REVERSE(SUBSTRING(REVERSE(PT.TYPENAME), 1, CHARINDEX('.', REVERSE(PT.TYPENAME)) - 1)))
+		END AS [Type],
+		site.SiteName
+	FROM tbSecret s
+	JOIN tbSecretType t ON s.SecretTypeID = t.SecretTypeID
+	JOIN tbPasswordType pt ON t.PasswordTypeId = pt.PasswordTypeId
+	JOIN tbSite site ON site.SiteId = s.SiteId
+	WHERE s.IsSSHProxyEnabled = 1 AND s.Active = 1
+) list
 UNION ALL
 
 SELECT '--> Number of Checkout Enabled Secrets', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbSecret s
 WHERE s.CheckoutEnabled = 1 AND s.Active = 1
-
 UNION ALL
 
 SELECT '--> Number of Comment Required Secrets', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbSecret s
 WHERE s.RequireViewComment = 1 AND s.Active = 1
-
 UNION ALL
 
 SELECT '--> Secrets Requiring Approval', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbSecret s
 WHERE s.RequireApprovalForAccess = 1 OR s.RequireApprovalForAccessForEditors = 1 OR s.RequireApprovalForAccessForOwnersAndApprovers = 1
-
 UNION ALL
 
 SELECT 'Core Setup' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
 SELECT '--> Event Pipeline Policies', CAST(COUNT(epp.EventPipelinePolicyId) AS NVARCHAR(50)), ''
@@ -459,72 +533,106 @@ FROM tbEventPipelinePolicy epp
 JOIN tbEventPipelinePolicyMap eppm ON eppm.EventPipelinePolicyId = epp.EventPipelinePolicyId
 JOIN tbEventPipeline ep ON eppm.EventPipelineId = ep.EventPipelineId
 WHERE epp.Active = 1 AND ep.Active = 1
-
 UNION ALL
 
 SELECT '--> Dependencies', CAST(COUNT(s.SecretId) AS NVARCHAR(50)), ''
 FROM tbSecretDependency d
 JOIN tbSecret s ON d.SecretId = s.SecretId
 WHERE d.Active = 1 AND s.Active = 1
-
 UNION ALL
 
 SELECT '--> Ticketing Systems', CAST(COUNT(ts.TicketSystemId) AS NVARCHAR(50)), ''
 FROM tbTicketSystem ts
 WHERE ts.Active = 1
-
 UNION ALL
 
 SELECT '--> Workflows', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbWorkflowTemplate
-
 UNION ALL
 
 SELECT '--> Teams', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbTeam
 WHERE Active = 1
+UNION ALL
 
+SELECT
+    '---> Members of team [' + t.TeamName + ']' AS [Item],
+    CAST(COUNT(DISTINCT u.UserId) AS VARCHAR) AS [Value],
+    '' AS [Comment]
+FROM tbTeam t
+INNER JOIN tbTeamGroupMembership tgm ON tgm.TeamId = t.TeamId
+INNER JOIN tbGroup g ON g.GroupId = tgm.GroupId
+INNER JOIN tbUserGroup ug ON g.GroupId = ug.GroupId
+INNER JOIN tbUser u ON u.UserId = ug.UserId
+WHERE (u.Enabled = 1 OR u.DisabledByAutomaticADUserDisabling = 1)
+    AND t.Active = 1
+    AND u.enabled = 1
+GROUP BY t.TeamName
 UNION ALL
 
 SELECT '--> QuantumLocks', CAST(COUNT(*) AS NVARCHAR(50)), ''
-FROM tbDoubleLock WHERE active = 1
-
+FROM tbDoubleLock
+WHERE active = 1
 UNION ALL
 
 SELECT '--> Event Subscriptions', CAST(COUNT(*) AS NVARCHAR(50)), ''
-FROM tbEventSubscription WHERE active = 1
-
+FROM tbEventSubscription
+WHERE active = 1
 UNION ALL
 
 SELECT '--> Categorized Lists', CAST(COUNT(*) AS NVARCHAR(50)), ''
-FROM tbCategorizedList WHERE active = 1
-
+FROM tbCategorizedList
+WHERE active = 1
 UNION ALL
 
 SELECT 'Session Recording' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
-SELECT '--> Session Recording Enabled', 
-    CAST(CASE 
-        WHEN c.EnableSessionRecording = 0 THEN 'FALSE' 
-        WHEN c.EnableSessionRecording = 1 THEN 'TRUE' 
-    END AS NVARCHAR(5)), ''
+SELECT '--> Session Recording Enabled',
+	CAST(CASE
+		WHEN c.EnableSessionRecording = 0 THEN 'FALSE'
+		WHEN c.EnableSessionRecording = 1 THEN 'TRUE'
+	END AS NVARCHAR(5)), ''
 FROM tbConfiguration c
-
 UNION ALL
 
-SELECT '--> Advanced Session Recording Enabled', 
-    CAST(CASE 
-        WHEN asr.Enabled = 0 THEN 'FALSE' 
-        WHEN asr.Enabled = 1 THEN 'TRUE' 
-    END AS NVARCHAR(5)), ''
+SELECT '--> Advanced Session Recording Enabled',
+	CAST(CASE
+		WHEN asr.Enabled = 0 THEN 'FALSE'
+		WHEN asr.Enabled = 1 THEN 'TRUE'
+	END AS NVARCHAR(5)), ''
 FROM tbAdvancedSessionRecordingConfiguration asr
+UNION ALL
 
+SELECT CONCAT('--> ASR Collection [', lac.Name, '] Agents'),
+	CAST(COUNT(la.LauncherAgentId) AS NVARCHAR(50)), ''
+FROM tbLauncherAgentCollection lac
+LEFT JOIN tbLauncherAgent la ON lac.LauncherAgentCollectionId = la.LauncherAgentCollectionId AND la.Active = 1
+WHERE lac.Active = 1
+GROUP BY lac.LauncherAgentCollectionId, lac.Name
+UNION ALL
 
+SELECT '--> Recorded Sessions Stored in Database',
+	CAST(COUNT(*) AS NVARCHAR(50)),
+	'Oldest: ' + FORMAT(MIN(StartDate), 'yyyy/MM/dd') + ' | Newest: ' + FORMAT(MAX(StartDate), 'yyyy/MM/dd') AS [Comment]
+FROM tbLauncherSession
+WHERE FileSize > 0 AND IsDeleted = 0
+UNION ALL
+
+SELECT '--> Total Session Storage Size (MB)',
+	CAST(CAST(ROUND(SUM(CAST(FileSize AS BIGINT)) / 1024.0 / 1024.0, 0) AS INT) AS NVARCHAR(50)), ''
+FROM tbLauncherSession
+WHERE FileSize > 0 AND IsDeleted = 0
 UNION ALL
 
 SELECT 'Cleanup Items' AS [Item], '' AS [Value], '' AS [Comment]
+UNION ALL
+
+SELECT '--> Users' AS [Item], '' AS [Value], '' AS [Comment]
+UNION ALL
+
+SELECT '----> Users missing email address' AS [Item], CAST(COUNT(*) AS NVARCHAR(50)) AS [Value], '' AS [Comment]
+from tbuser u where (u.emailaddress like '' or u.emailaddress is null) and u.Enabled =  1
 UNION ALL
 
 SELECT '--> Secrets' AS [Item], '' AS [Value], '' AS [Comment]
@@ -551,7 +659,7 @@ UNION ALL
 
 SELECT '----> Secrets Without Owners' AS [Item], CAST(COUNT(*) AS NVARCHAR(50)) AS [Value], '' AS [Comment]
 FROM tbSecret s
-WHERE s.active = 1 
+WHERE s.active = 1
    AND s.secretid NOT IN (
 	SELECT s.[SecretId]
 	FROM dbo.tbSecretACL acl WITH (NOLOCK)
@@ -561,47 +669,48 @@ WHERE s.active = 1
 	WHERE acl.permissions = 15
    )
 UNION ALL
+
 SELECT '----> Secrets With Leading or Trailing Spaces' AS [Item], CAST(COUNT(*) AS NVARCHAR(50)) AS [Value], '' AS [Comment]
 FROM tbSecret s
 JOIN tbFolder f ON s.FolderID = f.FolderID
-WHERE s.SecretName LIKE ' %' OR s.SecretName LIKE '% ' AND s.Active = 1
+WHERE (s.SecretName LIKE ' %' OR s.SecretName LIKE '% ') AND s.Active = 1
 UNION ALL
 
-SELECT '----> Shared Secrets in Personal Folders', cast(COUNT(DISTINCT s.secretid) as NVARCHAR(50)),''
+SELECT '----> Shared Secrets in Personal Folders', CAST(COUNT(DISTINCT s.secretid) AS NVARCHAR(50)), ''
 FROM tbSecretACL acl WITH (NOLOCK)
 JOIN tbSecret s WITH (NOLOCK) ON s.SecretID = acl.SecretID AND s.Active = 1
-JOIN tbSecretType t ON t.SecretTypeid = s.SecretTypeID
 JOIN tbGroup g WITH (NOLOCK) ON acl.[GroupID] = g.[GroupID] AND (g.[Active] = 1 OR g.[IsPersonal] = 1)
 JOIN tbUserGroup ug WITH (NOLOCK) ON acl.[GroupID] = ug.[GroupID]
 JOIN tbUser u WITH (NOLOCK) ON ug.[UserID] = u.[UserId]
-LEFT JOIN vUserDisplayName vdn ON vdn.UserId = u.UserId
 LEFT JOIN tbFolder f WITH (NOLOCK) ON s.[FolderID] = f.[FolderId]
 LEFT JOIN tbUser fu WITH (NOLOCK) ON f.[UserId] = fu.[UserId]
+CROSS JOIN (SELECT PersonalFolderName FROM tbConfiguration) cfg
 LEFT JOIN (
-    SELECT 
+    SELECT
         sub_f.FolderID,
         root_owner.UserId,
         root_owner.DisplayName,
         root_owner.Enabled
     FROM tbFolder sub_f WITH (NOLOCK)
+    CROSS JOIN (SELECT PersonalFolderName FROM tbConfiguration) cfg2
     JOIN tbFolder root_f WITH (NOLOCK) ON (
-        sub_f.FolderPath LIKE '\' + (SELECT PersonalFolderName FROM tbConfiguration) + '\%' AND
-        root_f.FolderPath = '\' + (SELECT PersonalFolderName FROM tbConfiguration) + '\' + 
+        sub_f.FolderPath LIKE '\' + cfg2.PersonalFolderName + '\%' AND
+        root_f.FolderPath = '\' + cfg2.PersonalFolderName + '\' +
         SUBSTRING(
-            sub_f.FolderPath, 
-            LEN((SELECT PersonalFolderName FROM tbConfiguration)) + 3,
-            CASE 
-                WHEN CHARINDEX('\', sub_f.FolderPath, LEN((SELECT PersonalFolderName FROM tbConfiguration)) + 3) > 0
-                THEN CHARINDEX('\', sub_f.FolderPath, LEN((SELECT PersonalFolderName FROM tbConfiguration)) + 3) - LEN((SELECT PersonalFolderName FROM tbConfiguration)) - 3
-                ELSE LEN(sub_f.FolderPath) - LEN((SELECT PersonalFolderName FROM tbConfiguration)) - 2
+            sub_f.FolderPath,
+            LEN(cfg2.PersonalFolderName) + 3,
+            CASE
+                WHEN CHARINDEX('\', sub_f.FolderPath, LEN(cfg2.PersonalFolderName) + 3) > 0
+                THEN CHARINDEX('\', sub_f.FolderPath, LEN(cfg2.PersonalFolderName) + 3) - LEN(cfg2.PersonalFolderName) - 3
+                ELSE LEN(sub_f.FolderPath) - LEN(cfg2.PersonalFolderName) - 2
             END
         )
     )
     LEFT JOIN tbUser root_owner WITH (NOLOCK) ON root_f.UserId = root_owner.UserId
     WHERE sub_f.UserId IS NULL
 ) parent_owner ON f.FolderID = parent_owner.FolderID
-WHERE f.FolderPath LIKE '\' + (SELECT PersonalFolderName FROM tbConfiguration) + '%'
-AND (parent_owner.userid <> u.UserId OR fu.userid <> u.userid)
+WHERE f.FolderPath LIKE '\' + cfg.PersonalFolderName + '%'
+  AND (parent_owner.userid <> u.UserId OR fu.userid <> u.userid)
 UNION ALL
 
 SELECT '--> Templates' AS [Item], '' AS [Value], '' AS [Comment]
@@ -639,8 +748,8 @@ SELECT '----> Secrets in Inactive Personal Folders' AS [Item], CAST(COUNT(*) AS 
 FROM tbSecret s
 JOIN tbFolder f ON s.FolderId = f.FolderID
 JOIN tbUser u ON f.UserId = u.UserId
-WHERE  f.FolderPath LIKE '%'+ (SELECT PersonalFolderName FROM tbConfiguration)+ '\%' 
-	AND s.Active = 1 
+WHERE  f.FolderPath LIKE '%'+ (SELECT PersonalFolderName FROM tbConfiguration)+ '\%'
+	AND s.Active = 1
 	AND u.Enabled = 0
 UNION ALL
 
@@ -658,19 +767,16 @@ WHERE f.FolderId NOT IN (
 ) AND f.FolderName <> (SELECT PersonalFolderName FROM tbConfiguration)
 UNION ALL
 SELECT '----> Incorrect folderpaths' AS [Item], CAST(COUNT(*) AS NVARCHAR(50)) AS [Value], '' AS [Comment]
-FROM tbfolder f 
+FROM tbfolder f
 JOIN tbfolder p ON p.folderid = f.ParentFolderId
 WHERE f.folderpath NOT LIKE p.folderpath + '%'
 UNION ALL
-
 SELECT 'Reporting' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
 SELECT '--> Custom SQL Reports', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbCustomReport
 WHERE IsStandardReport <> 1
-
 UNION ALL
 
 SELECT '--> SQL Report Schedules', CAST(COUNT(*) AS NVARCHAR(50)), ''
@@ -678,22 +784,18 @@ FROM tbSchedule sch
 FULL JOIN tbScheduledReport sr ON sr.ScheduleId = sch.ScheduleId
 JOIN tbCustomReport rep ON rep.CustomReportId = sr.ReportId
 WHERE sch.Active = 1 AND rep.Active = 1
-
 UNION ALL
 
 SELECT '--> SQL Reports or Categories with Custom Permissions', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbReportACL
-
 UNION ALL
 
 SELECT 'SDK' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
 SELECT '--> Active SDK Accounts', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbSdkClientAccount
 WHERE Revoked <> 1
-
 UNION ALL
 
 SELECT '--> SDK Unique Client IPs', CAST(COUNT(DISTINCT IpAddress) AS NVARCHAR(50)), ''
@@ -701,32 +803,57 @@ FROM tbSdkClientAccount
 UNION ALL
 
 SELECT 'Privilege Manager' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
 SELECT '--> Privilege Manager Folder Path', f.FolderPath, ''
 FROM tbfolder f
 WHERE f.FolderId = (
-    SELECT TOP 1 a.FolderId
-    FROM tbAuditFolder a
-    WHERE a.FolderPath = '\Privilege Manager Secrets'
+	SELECT TOP 1 a.FolderId
+	FROM tbAuditFolder a
+	WHERE a.FolderPath = '\Privilege Manager Secrets'
 )
-
 UNION ALL
 
 SELECT '--> Privilege Manager Secret Count', CAST(COUNT(s.SecretId) AS NVARCHAR(50)), ''
 FROM tbSecret s
 WHERE s.FolderId = (
-    SELECT TOP 1 a.FolderId
-    FROM tbAuditFolder a
-    WHERE a.FolderPath = '\Privilege Manager Secrets'
+	SELECT TOP 1 a.FolderId
+	FROM tbAuditFolder a
+	WHERE a.FolderPath = '\Privilege Manager Secrets'
 ) AND s.Active = 1
-
 UNION ALL
 
 SELECT 'Metadata' AS [Item], '' AS [Value], '' AS [Comment]
-
 UNION ALL
 
 SELECT '--> Metadata Items', CAST(COUNT(*) AS NVARCHAR(50)), ''
 FROM tbMetadataItemData mid
+
+/*
+LEGACY variant of Platform_Migration_Inventory.sql - compatibility notes.
+
+Supported floor
+  Secret Server 11.0 or later.
+  SQL Server 2016 (compatibility level 130) or later.
+
+Deliberate differences from Platform_Migration_Inventory.sql
+  1. Nothing reads tbPlatformConfiguration, so '--> UsePlatformSettings' is omitted. That table
+     arrives in Secret Server 11.1 (SqlServer/11.1/000005.sql) and its UsePlatformSettings column
+     only in 11.5 (SqlServer/11.5/000012.sql). A missing table or column is a compile-time error
+     and cannot be guarded inside a single statement, so neither can be made conditional. The row
+     also carries no information for this audience: UsePlatformSettings is the unified-mode flag,
+     and an instance below 11.5 cannot be in unified mode, so the answer is always 'Disabled'.
+  2. No STRING_AGG anywhere. STRING_AGG is SQL Server 2017+. The Platform Adoption Ready comment is
+     built with STUFF over fixed CASE fragments, which reproduces the same ': '-joined output.
+  3. No XML-PATH string concatenation anywhere. The two name lists that the main report folds into a
+     Comment with that pattern are emitted as their own rows instead:
+       '----> IdP [name]'                  one row per active SAML IdP
+       '----> [source - scannertype]'      one row per active discovery source
+     '--> Discovery Sources' therefore keeps the simple COUNT over tbDiscoverySource rather than
+     counting across the join to tbDiscoveryScanner.
+
+Secret Server report engine rules observed here
+  No CTEs (derived tables only). No XML-PATH concatenation. No trailing semicolon. No SET statements.
+  No inline '--' comments. No 'user' token in an output column name - note the deliberate
+  'Custom Us'+'er Ownership' string split in the Platform Adoption Ready checks.
+*/

--- a/Reports/SecretServer/PlatformMigration/Platform_Migration_Inventory.sql
+++ b/Reports/SecretServer/PlatformMigration/Platform_Migration_Inventory.sql
@@ -1,4 +1,4 @@
-SELECT 'Report Version' AS [Item], '1.4.20260721' AS [Value], '' AS [Comment]
+SELECT 'Report Version' AS [Item], '2.0.20260807' AS [Value], '' AS [Comment]
 UNION ALL
 
 SELECT 'Report Date' AS [Item], 


### PR DESCRIPTION
## Why

`LEGACY-Platform_Migration_Inventory.sql` was last updated 2025-09-12 (`1.4.20250909-LEGACY`). The main report was rewritten on 2026-07-20 (`1.4.20260721`) and none of it was backported, so the LEGACY variant has been ~11 months behind — giving a materially worse inventory for exactly the customers most likely to be pre-migration.

This rebases LEGACY onto main's current text so nothing is missed, then applies only the deltas needed to keep it runnable on old estates.

## What actually constrains the LEGACY variant

Two things, and only two:

**SQL Server 2016.** Exactly one construct in main is incompatible: `STRING_AGG` (2017+), used once. Everything else — `FOR XML PATH`, `FORMAT`, `PARSENAME`, `CROSS APPLY`, windowed `COUNT() OVER` — runs fine on 2016.

**Secret Server 11.0 floor.** Every table and column main added predates 10.9, so all of it backports. The sole exception is `tbPlatformConfiguration`, which arrives in 11.1, and its `UsePlatformSettings` column only in 11.5. Nothing in this file reads that table.

## Renumbering both reports to 2.0

Separate from the backport, and the reason this PR touches `Platform_Migration_Inventory.sql` too.

Both reports had been static on `1.4` since 2024 with only the trailing date iterating, through
multiple customer-facing releases — including the 2026-07-20 rewrite, which changed logic, fixed
bugs and added rows. Under our convention (major = ships to customer) that should have gone major
some time ago.

| File | Was | Now |
|---|---|---|
| `Platform_Migration_Inventory.sql` | `1.4.20260721` | `2.0.20260807` |
| `LEGACY-Platform_Migration_Inventory.sql` | `1.4.20250909-LEGACY` | `2.0.20260806-LEGACY` |

They now share `major.minor`, so the `-LEGACY` suffix is the only difference — the suffix denotes
reach (SS 11.0+ / SQL 2016), not a different generation of the report. Previously the two numbers
gave no indication whether two outputs were comparable.

The change to `Platform_Migration_Inventory.sql` is **one line** — the version string. No logic touched.

## Changes to the LEGACY report

1. Version → `2.0.20260806-LEGACY` (see Renumbering below).
2. `--> UsePlatformSettings` row dropped. A missing table or column is a compile-time error and cannot be guarded inside a single statement. It also carries no information for this audience: `UsePlatformSettings` is the unified-mode flag, and an instance below 11.5 cannot be in unified mode, so the answer is always `Disabled`.
3. `STRING_AGG` in Platform Adoption Ready replaced with `STUFF` over `MAX(CASE WHEN SortOrder = n ...)` fragments. The check list is fixed and small, so this is exact.
4. The two unbounded name lists are emitted as sub-rows rather than aggregated comments:
   - `----> IdP [name]` — one row per active SAML IdP
   - `----> [source - scannertype]` — one row per active discovery source

   This avoids `STRING_AGG` (2017+) **and** `FOR XML PATH`, so the LEGACY variant needs neither. `--> Discovery Sources` therefore keeps the simple `COUNT` over `tbDiscoverySource` rather than counting across the join to `tbDiscoveryScanner`.
5. **No comments in the file.** A trailing `/* */` notes block had to be removed before the report would run in Secret Server. Block comments are not necessarily the problem — more likely something *inside* the block tripped one of the engine's validation checks. A strong candidate: the block contained the quoted word `'user'` (in a note about the `user`-token restriction), and if that check scans the raw SQL text rather than just column aliases, a comment would trip it exactly like a real alias would.

Not worth chasing. The main report ships comment-free and the general rule is to include comments only where they're required, so LEGACY now matches. The compatibility notes live in this description instead.

### Compatibility notes (previously in-file)

- **Supported floor:** Secret Server 11.0+, SQL Server 2016 (compatibility level 130)+.
- Nothing reads `tbPlatformConfiguration`. That table arrives in SS 11.1 and its `UsePlatformSettings` column only in 11.5.
- No `STRING_AGG` (2017+). No XML-PATH concatenation. No CTEs, derived tables only. No trailing semicolon. No `SET` statements. No comments of any kind.
- No `user` token in output text — note the deliberate `'Custom Us'+'er Ownership'` string split in the adoption checks. Do not "tidy" that into one literal.

Everything else from the 2026-07-20 rewrite is carried over verbatim: the ~20x perf work, the AND/OR precedence fix on the leading/trailing-space check, the `PARSENAME` version parse, the re-tiered Migration Package Size, the Proxying Config section, Secret Hooks, team membership, ASR collections, session storage, and the users-missing-email cleanup row.

A whitespace-normalised diff against `Platform_Migration_Inventory.sql` shows those five changes and nothing else. `UNION ALL` branch count 121 → 122 (−1 removed row, +2 sub-row branches).

## Testing

- Static gates: no `STRING_AGG`, no `FOR XML`, no CTEs, no trailing semicolon, no `SET` statements, 7-bit ASCII, no BOM.
- Executed against a live Secret Server DB (SQL Server 16.0.4155.4, SS 12.1.000002): the three changed query blocks, plus a direct `STRING_AGG`-vs-`STUFF` parity comparison — byte-identical output with all seven adoption checks firing, and the empty-check-set case correctly yields `Yes` with an empty comment.
- **Run in Secret Server itself**, which is how the trailing comment block was caught and removed.
- **Not** tested: no run against an actual 2016-level or sub-11.5 instance. The unchanged ~95% is main's production text; the 2016 claim rests on a construct sweep rather than a 2016 execution. Flagging that explicitly since it is the main residual risk — worth a run on a real old estate before this leaves draft.

## Two things worth a maintainer's eye

1. **`FOR XML PATH` in the main report.** The internal `secretserver-sql-reports` guidance states the SS report engine rejects `FOR XML PATH` and mandates `STRING_AGG`. Main uses `FOR XML PATH` twice and ships, so one of those is wrong. This PR sidesteps the question for LEGACY, but it is worth settling — it affects every report in this folder.
2. **Possible bug in main, not fixed here.** The rewrite changed `--> Discovery Sources` to count across a join to `tbDiscoveryScanner`. On the test instance it matches (4 = 4, one scanner per source), but a source with multiple scanners would skew the count. LEGACY keeps the simpler count; main may want the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
